### PR TITLE
Added stream for pageable.

### DIFF
--- a/src/main/java/com/blog/stream/pagination/PageableSpliterator.java
+++ b/src/main/java/com/blog/stream/pagination/PageableSpliterator.java
@@ -1,0 +1,147 @@
+package com.blog.stream.pagination;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class PageableSpliterator<T> implements Spliterator<T> {
+
+    static final int PAGED_SPLITERATOR_CHARACTERISTICS = ORDERED | IMMUTABLE | SIZED | SUBSIZED | CONCURRENT;
+
+    static <R> PageableSpliterator<R> create(final Pageable pageable, final Function<Pageable, Page<R>> pageFetcher) {
+        return new PageableSpliterator<>(pageable, pageFetcher);
+    }
+
+    private final Function<Pageable, Page<T>> pageFetcher;
+    private       Pageable                    pageable;
+    private       Page<T>                     preFetchedPage;
+
+    PageableSpliterator(
+            final Pageable pageable,
+            final Function<Pageable, Page<T>> pageFetcher) {
+        this.pageable    = pageable;
+        this.pageFetcher = pageFetcher;
+    }
+
+    @Override
+    public boolean tryAdvance(final Consumer<? super T> action) {
+        Page<T> page = pageFetcher.apply(pageable);
+        page.forEach(action);
+
+        //in parallel mode this section will always be run on the last page
+        if (page.hasNext()) {
+            pageable = pageable.next();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Spliterator<T> trySplit() {
+        if (preFetchedPage == null) {
+            prefetchPage();
+        }
+
+        if (pageable.getPageNumber() + 1 >= preFetchedPage.getTotalPages()) {
+            return null;
+        }
+
+        if (pageable.getPageNumber() == 0) {
+            pageable = pageable.next();
+            return new PreFetchedChildPageSpliterator<>(preFetchedPage);
+        }
+
+        ChildPageSpliterator<T> childSpliterator = new ChildPageSpliterator<>(pageable, pageFetcher);
+        pageable = pageable.next();
+        return childSpliterator;
+    }
+
+    @Override
+    public long estimateSize() {
+        if (preFetchedPage == null) {
+            prefetchPage();
+        }
+
+        return preFetchedPage.getTotalElements();
+    }
+
+    @Override
+    public int characteristics() {
+        return PAGED_SPLITERATOR_CHARACTERISTICS;
+    }
+
+    private void prefetchPage() {
+        preFetchedPage = pageFetcher.apply(pageable);
+    }
+
+    static class ChildPageSpliterator<T> implements Spliterator<T> {
+
+        private final Pageable                    pageable;
+        private final Function<Pageable, Page<T>> pageFetcher;
+
+        private ChildPageSpliterator(
+                final Pageable pageable,
+                final Function<Pageable, Page<T>> pageFetcher) {
+            this.pageable    = pageable;
+            this.pageFetcher = pageFetcher;
+        }
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super T> action) {
+            Page<T> page = pageFetcher.apply(pageable);
+            page.forEach(action);
+            return false;
+        }
+
+        @Override
+        public Spliterator<T> trySplit() {
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return pageable.getPageSize();
+        }
+
+        @Override
+        public int characteristics() {
+            return ORDERED | IMMUTABLE | SIZED;
+        }
+
+    }
+
+    static class PreFetchedChildPageSpliterator<T> implements Spliterator<T> {
+
+        private final Page<T> page;
+
+        PreFetchedChildPageSpliterator(final Page<T> page) {
+            this.page = page;
+        }
+
+
+        @Override
+        public boolean tryAdvance(final Consumer<? super T> action) {
+            page.forEach(action);
+            return false;
+        }
+
+        @Override
+        public Spliterator<T> trySplit() {
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            return page.getPageable().getPageSize();
+        }
+
+        @Override
+        public int characteristics() {
+            return ORDERED | IMMUTABLE | SIZED;
+        }
+
+    }
+}

--- a/src/main/java/com/blog/stream/pagination/PaginationUtils.java
+++ b/src/main/java/com/blog/stream/pagination/PaginationUtils.java
@@ -1,5 +1,9 @@
 package com.blog.stream.pagination;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -7,10 +11,6 @@ import java.util.stream.StreamSupport;
 import static com.blog.stream.pagination.PageSpliterator.PAGED_SPLITERATOR_CHARACTERISTICS;
 
 public final class PaginationUtils {
-    private PaginationUtils() {
-
-    }
-
     /**
      * Create lazily loaded stream for paginated queries. Stream type returned is sequential by default
      * performing pagedStream(...).parallel() will provided parallel stream.
@@ -46,7 +46,6 @@ public final class PaginationUtils {
         return StreamSupport.stream(spliterator, PAGED_SPLITERATOR_CHARACTERISTICS, false);
     }
 
-
     /**
      * Stream over paginated result set without having to know the size of the result set beforehand.
      * First page is obtained when attempting to split.
@@ -59,5 +58,23 @@ public final class PaginationUtils {
     public static <T> Stream<T> prefetchPageStream(final PageFetcher<T> fetcher, final int pageSize) {
         PreFetchPageSpliterator<T> spliterator = PreFetchPageSpliterator.create(pageSize, fetcher);
         return StreamSupport.stream(spliterator, false);
+    }
+
+    /**
+     * Stream over paginated result set without having to know the size of the result set beforehand.
+     * First page is obtained when attempting to split.
+     *
+     * @param fetcher  Interface for retrieving pages
+     * @param pageable Pageable to use for the queries
+     * @param <T>      Generic type returned by page fetched
+     * @return Stream of generic type T
+     */
+    public static <T> Stream<T> pageableStream(final Function<Pageable, Page<T>> fetcher, final Pageable pageable) {
+        PageableSpliterator<T> spliterator = PageableSpliterator.create(pageable, fetcher);
+        return StreamSupport.stream(spliterator, false);
+    }
+
+    private PaginationUtils() {
+
     }
 }

--- a/src/test/java/com/blog/stream/pagination/PageSpliteratorTest.java
+++ b/src/test/java/com/blog/stream/pagination/PageSpliteratorTest.java
@@ -15,12 +15,12 @@ public class PageSpliteratorTest {
     public JUnitSoftAssertions soft = new JUnitSoftAssertions();
 
     @Test
-    public void trySplit_ReturnsChildWithCurrentPageAndMovesOnToNextPage() throws Exception {
+    public void trySplit_ReturnsChildWithCurrentPageAndMovesOnToNextPage() {
         PageSpliterator<String> spliterator = new PageSpliterator<>(3, 100, 10, null);
 
         Spliterator<String> child = spliterator.trySplit();
 
-        soft.assertThat(((PageSpliterator.ChildPageSpliterator) child).getPageNumber())
+        soft.assertThat(((PageSpliterator.ChildPageSpliterator<String>) child).getPageNumber())
                 .isEqualTo(3);
 
         soft.assertThat(spliterator.getPageNumber())


### PR DESCRIPTION
Nice work!

I adapted it so it can be used for generic fetchers of the type Function<Pageable, Page<T>>. In this way one can just feed it with the JpaRepository:::findAll method.

Remove throw Exception from all test methods, as they aren't needed.